### PR TITLE
Ensured that the CC65 runtime is reset properly on console reset.

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -19,6 +19,8 @@ void __fastcall__ bootstrap(void) {
 }
 
 int main(void) {
+  *CHECKSUM = 0x23; // Ensure cold-start in case the user resets the console.
+
   clrscr();
   printf("                       _________ \n");
   printf("                      |         |\n");

--- a/src/menu.h
+++ b/src/menu.h
@@ -10,6 +10,7 @@
 
 #define CCTL ((unsigned char *) 0xD500)
 #define DOSVEC ((unsigned int *) 0x0A)
+#define CHECKSUM ((unsigned char *) 0x33D) // NOTE RAM checksum, if changed the OS will perform a cold-start.
 
 #define BOOTSTRAP_SIZE 0x400                     // FIXME Compute the size somehow.
 #define BOOTSTRAP_AREA (0x8000 - BOOTSTRAP_SIZE) // NOTE Right before the second cart bank.


### PR DESCRIPTION
Fixes #26 